### PR TITLE
Fixed logging of internal errors

### DIFF
--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -60,7 +60,7 @@ namespace ElmahCore.Mvc
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError("Error in filters XML file", e);
+                    _logger.LogError(e, "Error in filters XML file");
                 }
             }
 
@@ -193,7 +193,7 @@ namespace ElmahCore.Mvc
             }
             catch(Exception e)
             {
-                _logger.LogError("Elmah request processing error", e);
+                _logger.LogError(e, "Elmah request processing error");
             }
         }
 
@@ -258,7 +258,7 @@ namespace ElmahCore.Mvc
                 // even system ones and potentially let them slip by.
                 //
 
-                _logger.LogError("Elmah local exception", localException);
+                _logger.LogError(localException, "Elmah local exception");
             }
             if (entry != null)
                 OnLogged(new ErrorLoggedEventArgs(entry));


### PR DESCRIPTION
Hi there! I found when ElmahCore itself was throwing exceptions, only the title, e.g. "Elmah local exception" was showing up in application logs (in my case, the stdout_xxx log files generated in /logs/ after enabling in Web.config). Changing the calls to _logger.LogError to include the exception object as first argument now causes the full exception with stack trace to be included in application logs.
