### PR TITLE
Allow ApplicationName to be set via ElmahOptions

### DIFF
--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.PlatformAbstractions;
 
 namespace ElmahCore.Mvc
 {
@@ -71,6 +72,15 @@ namespace ElmahCore.Mvc
             }
             if (!_elmahRoot.StartsWith("/")) _elmahRoot = "/" + _elmahRoot;
             if (_elmahRoot.EndsWith("/")) _elmahRoot = _elmahRoot.Substring(0,_elmahRoot.Length-1);
+
+            if (elmahOptions?.Value?.ApplicationName != null)
+            {
+                _errorLog.ApplicationName = elmahOptions.Value.ApplicationName;
+            }
+            else
+            {
+                _errorLog.ApplicationName = $"{PlatformServices.Default.Application.ApplicationName}({PlatformServices.Default.Application.ApplicationVersion})";
+            }
         }
 
         private void ConfigureFilters(string config)

--- a/ElmahCore/ElmahOptions.cs
+++ b/ElmahCore/ElmahOptions.cs
@@ -15,6 +15,7 @@ namespace ElmahCore
         public ErrorLog EventLog { get; set; }
         public string ConnectionString { get; set; }
 	    public Func<HttpContext,bool> CheckPermissionAction { get; set; }
+        public string ApplicationName { get; set; }
     }
 
 }

--- a/ElmahCore/Logs$/ErrorLog.cs
+++ b/ElmahCore/Logs$/ErrorLog.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.PlatformAbstractions;
 
 namespace ElmahCore
 {
@@ -24,8 +23,6 @@ namespace ElmahCore
 
         protected ErrorLog()
         {
-            ApplicationName = $"{PlatformServices.Default.Application.ApplicationName}({PlatformServices.Default.Application.ApplicationVersion})";
-
         }
 
         /// <summary>


### PR DESCRIPTION
To allow setting ApplicationName to a custom value, moved initialization of ApplicaitonName from ErrorLog to ErrorLogMiddleware so that it can be set via ElmahOptions. Will still default to the original value from PlatformServices.Default.Application if no value is given in options.