### PR TITLE
elmahcore/elmahcore#51 - NullReference Check

### DIFF
--- a/ElmahCore/Error.cs
+++ b/ElmahCore/Error.cs
@@ -168,6 +168,12 @@ namespace ElmahCore
 	            bool isProcessed = false;
                 if (value is IEnumerable en && !(en is string))
                 {
+	                if (en.GetType().FullName.StartsWith("Microsoft.AspNetCore.Http.ItemsDictionary")) {
+						try { en.GetEnumerator(); } catch
+						{
+							continue;
+						}
+	                }
 	                foreach (var item in en)
                     {
                         try


### PR DESCRIPTION
https://github.com/ElmahCore/ElmahCore/issues/51

As best I can tell, it looks like the underlying issue might be a bug for Microsoft to fix. The internal `Microsoft.AspNetCore.Http.ItemsDictionary`'s `.GetEnumerator()` function can throw a NullReferenceException if the dictionary has never been used (and the internal `_items` member is null).

The patch, will swallow that exception in order to allow Elmah to continue processing.