### PR TITLE
elmahcore/elmahcore#51 - NullReference Check (2nd Pass)

### DIFF
--- a/ElmahCore/Error.cs
+++ b/ElmahCore/Error.cs
@@ -16,22 +16,22 @@ using Microsoft.Extensions.Primitives;
 
 namespace ElmahCore
 {
-	/// <summary>
-	/// Represents a logical application error (as opposed to the actual 
-	/// exception it may be representing).
-	/// </summary>
+    /// <summary>
+    /// Represents a logical application error (as opposed to the actual 
+    /// exception it may be representing).
+    /// </summary>
 
-	[ Serializable ]
+    [ Serializable ]
     public sealed class Error : ICloneable
     {
-		private string _applicationName;
+        private string _applicationName;
         private string _hostName;
         private string _typeName;
         private string _source;
         private string _message;
         private string _detail;
         private string _user;
-		private string _webHostHtmlMessage;
+        private string _webHostHtmlMessage;
         private NameValueCollection _serverVariables;
         private NameValueCollection _queryString;
         private NameValueCollection _form;
@@ -135,9 +135,9 @@ namespace ElmahCore
             LoadVariables(serverVariables, () => context.Features, "");
             LoadVariables(serverVariables, () => context.User, "User_");
 
-	        var ss = context.RequestServices?.GetService(typeof(ISession));
-			if (ss != null)
-				LoadVariables(serverVariables, () => context.Session, "Session_");
+            var ss = context.RequestServices?.GetService(typeof(ISession));
+            if (ss != null)
+                LoadVariables(serverVariables, () => context.Session, "Session_");
             LoadVariables(serverVariables, () => context.Items, "Items_");
             LoadVariables(serverVariables, () => context.Connection, "Connection_");
             return serverVariables;
@@ -160,21 +160,19 @@ namespace ElmahCore
                 {
                     value = prop.GetValue(obj);
                 }
-	            catch
-	            {
-		            // ignored
-	            }
+                catch
+                {
+                    // ignored
+                }
 
-	            bool isProcessed = false;
+                bool isProcessed = false;
                 if (value is IEnumerable en && !(en is string))
                 {
-	                if (en.GetType().FullName.StartsWith("Microsoft.AspNetCore.Http.ItemsDictionary")) {
-						try { en.GetEnumerator(); } catch
-						{
-							continue;
-						}
-	                }
-	                foreach (var item in en)
+                    if (value is IDictionary<object, object> dic)
+                    {
+                        if(dic.Keys.Count == 0) { continue; }
+                    }
+                    foreach (var item in en)
                     {
                         try
                         {
@@ -192,10 +190,10 @@ namespace ElmahCore
                                 }
                             }
                         }
-	                    catch
-	                    {
-		                    // ignored
-	                    }
+                        catch
+                        {
+                            // ignored
+                        }
                     }
                 }
                 if (!isProcessed)
@@ -204,36 +202,36 @@ namespace ElmahCore
                     {
                         if (value == null || value.GetType().ToString() != value.ToString()) serverVariables.Add(prefix + prop.Name, value?.ToString());
                     }
-	                catch
-	                {
-		                // ignored
-	                }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
             }
         }
 
 
-		/// <summary>
-		/// Gets the <see cref="Exception"/> instance used to initialize this
-		/// instance.
-		/// </summary>
-		/// <remarks>
-		/// This is a run-time property only that is not written or read 
-		/// during XML serialization via <see cref="ErrorXml.Decode"/> and 
-		/// <see cref="ErrorXml.Encode(Error,XmlWriter)"/>.
-		/// </remarks>
+        /// <summary>
+        /// Gets the <see cref="Exception"/> instance used to initialize this
+        /// instance.
+        /// </summary>
+        /// <remarks>
+        /// This is a run-time property only that is not written or read 
+        /// during XML serialization via <see cref="ErrorXml.Decode"/> and 
+        /// <see cref="ErrorXml.Encode(Error,XmlWriter)"/>.
+        /// </remarks>
 
-		public Exception Exception { get; }
+        public Exception Exception { get; }
 
-		/// <summary>
-		/// Gets or sets the name of application in which this error occurred.
-		/// </summary>
+        /// <summary>
+        /// Gets or sets the name of application in which this error occurred.
+        /// </summary>
 
-		public string ApplicationName
+        public string ApplicationName
         { 
             get => _applicationName ?? string.Empty;
-		    set => _applicationName = value;
-	    }
+            set => _applicationName = value;
+        }
 
         /// <summary>
         /// Gets or sets name of host machine where this error occurred.
@@ -241,8 +239,8 @@ namespace ElmahCore
         
         public string HostName
         { 
-	        get => _hostName ?? Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
-	        set => _hostName = value;
+            get => _hostName ?? Environment.GetEnvironmentVariable("COMPUTERNAME") ?? Environment.GetEnvironmentVariable("HOSTNAME");
+            set => _hostName = value;
         }
 
         /// <summary>
@@ -252,7 +250,7 @@ namespace ElmahCore
         public string Type
         { 
             get => _typeName ?? string.Empty;
-	        set => _typeName = value;
+            set => _typeName = value;
         }
 
         /// <summary>
@@ -262,7 +260,7 @@ namespace ElmahCore
         public string Source
         { 
             get => _source ?? string.Empty;
-	        set => _source = value;
+            set => _source = value;
         }
 
         /// <summary>
@@ -272,7 +270,7 @@ namespace ElmahCore
         public string Message 
         { 
             get => _message ?? string.Empty;
-	        set => _message = value;
+            set => _message = value;
         }
 
         /// <summary>
@@ -283,7 +281,7 @@ namespace ElmahCore
         public string Detail
         { 
             get => _detail ?? string.Empty;
-	        set => _detail = value;
+            set => _detail = value;
         }
 
         /// <summary>
@@ -293,38 +291,38 @@ namespace ElmahCore
         
         public string User 
         { 
-	        get => _user ?? Environment.GetEnvironmentVariable("USERDOMAIN") ?? Environment.GetEnvironmentVariable("USERNAME") ?? string.Empty;
+            get => _user ?? Environment.GetEnvironmentVariable("USERDOMAIN") ?? Environment.GetEnvironmentVariable("USERNAME") ?? string.Empty;
 
-	        set => _user = value;
+            set => _user = value;
         }
 
-		/// <summary>
-		/// Gets or sets the date and time (in local time) at which the 
-		/// error occurred.
-		/// </summary>
+        /// <summary>
+        /// Gets or sets the date and time (in local time) at which the 
+        /// error occurred.
+        /// </summary>
 
-		public DateTime Time { get; set; }
+        public DateTime Time { get; set; }
 
-		/// <summary>
-		/// Gets or sets the HTTP status code of the output returned to the 
-		/// client for the error.
-		/// </summary>
-		/// <remarks>
-		/// For cases where this value cannot always be reliably determined, 
-		/// the value may be reported as zero.
-		/// </remarks>
+        /// <summary>
+        /// Gets or sets the HTTP status code of the output returned to the 
+        /// client for the error.
+        /// </summary>
+        /// <remarks>
+        /// For cases where this value cannot always be reliably determined, 
+        /// the value may be reported as zero.
+        /// </remarks>
 
-		public int StatusCode { get; set; }
+        public int StatusCode { get; set; }
 
-		/// <summary>
-		/// Gets or sets the HTML message generated by the web host (ASP.NET) 
-		/// for the given error.
-		/// </summary>
+        /// <summary>
+        /// Gets or sets the HTML message generated by the web host (ASP.NET) 
+        /// for the given error.
+        /// </summary>
 
-		public string WebHostHtmlMessage
+        public string WebHostHtmlMessage
         {
             get => _webHostHtmlMessage ?? string.Empty;
-	        set => _webHostHtmlMessage = value;
+            set => _webHostHtmlMessage = value;
         }
 
         /// <summary>
@@ -334,28 +332,28 @@ namespace ElmahCore
         
         public NameValueCollection ServerVariables => FaultIn(ref _serverVariables);
 
-	    /// <summary>
+        /// <summary>
         /// Gets a collection representing the Web query string variables
         /// captured as part of diagnostic data for the error.
         /// </summary>
         
         public NameValueCollection QueryString => FaultIn(ref _queryString);
 
-	    /// <summary>
+        /// <summary>
         /// Gets a collection representing the form variables captured as 
         /// part of diagnostic data for the error.
         /// </summary>
         
         public NameValueCollection Form => FaultIn(ref _form);
 
-	    /// <summary>
+        /// <summary>
         /// Gets a collection representing the client cookies
         /// captured as part of diagnostic data for the error.
         /// </summary>
 
         public NameValueCollection Cookies => FaultIn(ref _cookies);
 
-	    /// <summary>
+        /// <summary>
         /// Returns the value of the <see cref="Message"/> property.
         /// </summary>
 
@@ -388,10 +386,10 @@ namespace ElmahCore
             return copy;
         }
 
-	    public Error Clone()
-	    {
-		    return (Error) ((ICloneable) this).Clone();
-	    }
+        public Error Clone()
+        {
+            return (Error) ((ICloneable) this).Clone();
+        }
 
         private static NameValueCollection CopyCollection(NameValueCollection collection)
         {
@@ -402,12 +400,12 @@ namespace ElmahCore
         }
         private static NameValueCollection CopyCollection(IEnumerable<KeyValuePair<String, StringValues>> collection)
         {
-	        // ReSharper disable once PossibleMultipleEnumeration
-	        if (collection == null || !collection.Any())
-		        return null;
-	        // ReSharper disable once PossibleMultipleEnumeration
-	        var keyValuePairs = collection as KeyValuePair<string, StringValues>[] ?? collection.ToArray();
-	        if (!keyValuePairs.Any())
+            // ReSharper disable once PossibleMultipleEnumeration
+            if (collection == null || !collection.Any())
+                return null;
+            // ReSharper disable once PossibleMultipleEnumeration
+            var keyValuePairs = collection as KeyValuePair<string, StringValues>[] ?? collection.ToArray();
+            if (!keyValuePairs.Any())
                 return null;
             var col = new NameValueCollection();
             foreach (var pair in keyValuePairs)
@@ -441,7 +439,7 @@ namespace ElmahCore
 
         private static NameValueCollection FaultIn(ref NameValueCollection collection)
         {
-	        return collection ?? (collection = new NameValueCollection());
+            return collection ?? (collection = new NameValueCollection());
         }
     }
 }


### PR DESCRIPTION
In the previous pull request ([#52](https://github.com/ElmahCore/ElmahCore/pull/52)), the solution was to let `.GetEnumerator()` throw an exception and catch it. This can create exceptions that the low level .NET Profiler records; but they aren't real exceptions. This can create a high noise-to-signal ratio in APM tooling (not that many people that are using an APM are also using ELMAH).

This is a reimplementation of the check using a technique that won't throw an exception. In this version, the passed in `value` object is first tested to be an `IDictionary<object,object>` (instead of looking for `Microsoft.AspNetCore.Http.ItemsDictionary`) and checks if the `.Keys.Count == 0`. If there are no keys, then it will avoid the call to `.GetEnumerator()` which avoid the `NullReferenceException`.