### PR TITLE
elmahcore/elmahcore#51 - NullReference Check (3rd Pass)

### DIFF
--- a/ElmahCore/Error.cs
+++ b/ElmahCore/Error.cs
@@ -168,12 +168,10 @@ namespace ElmahCore
 	            bool isProcessed = false;
                 if (value is IEnumerable en && !(en is string))
                 {
-	                if (en.GetType().FullName.StartsWith("Microsoft.AspNetCore.Http.ItemsDictionary")) {
-						try { en.GetEnumerator(); } catch
-						{
-							continue;
-						}
-	                }
+	                if (value is IDictionary<object, object> dic)
+                    {
+                        if(dic.Keys.Count == 0) { continue; }
+                    }
 	                foreach (var item in en)
                     {
                         try


### PR DESCRIPTION
In the previous pull request (#52), the solution was to let .GetEnumerator() throw an exception and catch it. This can create exceptions that the low level .NET Profiler records; but they aren't real exceptions. This can create a high noise-to-signal ratio in APM tooling (not that many people that are using an APM are also using ELMAH).

This is a reimplementation of the check using a technique that won't throw an exception. In this version, the passed in value object is first tested to be an IDictionary<object,object> (instead of looking for Microsoft.AspNetCore.Http.ItemsDictionary) and checks if the .Keys.Count == 0. If there are no keys, then it will avoid the call to .GetEnumerator() which avoid the NullReferenceException.

This pull request left the white space alone.