### PR TITLE
Log actual exception raised in ErrorLogMiddleware

### DIFF
--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -261,7 +261,7 @@ namespace ElmahCore.Mvc
                 }
 
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 //
                 // IMPORTANT! We swallow any exception raised during the 
@@ -272,7 +272,7 @@ namespace ElmahCore.Mvc
                 // even system ones and potentially let them slip by.
                 //
 
-                _logger.LogError("Elmah local exception");
+                _logger.LogError(ex, "Elmah local exception");
             }
             if (entry != null)
                 OnLogged(new ErrorLoggedEventArgs(entry));


### PR DESCRIPTION
It's important that we do not swallow up exceptions raised in the middleware, otherwise the client is completely blind to the cause of middleware exceptions.