### PR TITLE
Allow sepcifying the error ID when logging

### DIFF
--- a/ElmahCore.MsSql/SqlErrorLog.cs
+++ b/ElmahCore.MsSql/SqlErrorLog.cs
@@ -52,11 +52,19 @@ namespace ElmahCore.Sql
 
         public override string Log(Error error)
         {
+            var id = Guid.NewGuid();
+
+            Log(id, error);
+
+            return id.ToString();
+        }
+
+        public override void Log(Guid id, Error error)
+        {
             if (error == null)
                 throw new ArgumentNullException(nameof(error));
 
             var errorXml = ErrorXml.EncodeString(error);
-            var id = Guid.NewGuid();
 
             using (var connection = new SqlConnection(ConnectionString))
             using (var command = Commands.LogError(id, ApplicationName, error.HostName, error.Type, error.Source, error.Message, error.User, error.StatusCode, error.Time, errorXml))
@@ -64,7 +72,6 @@ namespace ElmahCore.Sql
                 command.Connection = connection;
                 connection.Open();
                 command.ExecuteNonQuery();
-                return id.ToString();
             }
         }
 

--- a/ElmahCore.MySql/MySqlErrorLog.cs
+++ b/ElmahCore.MySql/MySqlErrorLog.cs
@@ -47,11 +47,19 @@ namespace ElmahCore.MySql
 
         public override string Log(Error error)
         {
+            var id = Guid.NewGuid();
+
+            Log(id, error);
+
+            return id.ToString();
+        }
+
+        public override void Log(Guid id, Error error)
+        {
             if (error == null)
                 throw new ArgumentNullException("error");
 
             var errorXml = ErrorXml.EncodeString(error);
-            var id = Guid.NewGuid();
 
             using (var connection = new MySqlConnection(ConnectionString))
             using (var command = CommandExtension.LogError(id, ApplicationName, error.HostName, error.Type, error.Source, error.Message, error.User, error.StatusCode, error.Time, errorXml))
@@ -59,7 +67,6 @@ namespace ElmahCore.MySql
                 connection.Open();
                 command.Connection = connection;
                 command.ExecuteNonQuery();
-                return id.ToString();
             }
         }
 

--- a/ElmahCore.Postgresql/PgsqlErrorLog.cs
+++ b/ElmahCore.Postgresql/PgsqlErrorLog.cs
@@ -57,11 +57,19 @@ namespace ElmahCore.Postgresql
 
         public override string Log(Error error)
         {
+            var id = Guid.NewGuid();
+
+            Log(id, error);
+
+            return id.ToString();
+        }
+
+        public override void Log(Guid id, Error error)
+        {
             if (error == null)
                 throw new ArgumentNullException("error");
 
             var errorXml = ErrorXml.EncodeString(error);
-            var id = Guid.NewGuid();
 
             using (var connection = new NpgsqlConnection(ConnectionString))
             using (var command = Commands.LogError(id, ApplicationName, error.HostName, error.Type, error.Source, error.Message, error.User, error.StatusCode, error.Time, errorXml))
@@ -69,7 +77,6 @@ namespace ElmahCore.Postgresql
                 command.Connection = connection;
                 connection.Open();
                 command.ExecuteNonQuery();
-                return id.ToString();
             }
         }
 

--- a/ElmahCore/Logs$/ErrorLog.cs
+++ b/ElmahCore/Logs$/ErrorLog.cs
@@ -26,6 +26,8 @@ namespace ElmahCore
         
         public abstract string Log(Error error);
 
+        public abstract void Log(Guid id, Error error);
+
         /// <summary>
         /// When overridden in a subclass, starts a task that asynchronously
         /// does the same as <see cref="Log"/>.

--- a/ElmahCore/Logs$/MemoryErrorLog.cs
+++ b/ElmahCore/Logs$/MemoryErrorLog.cs
@@ -81,6 +81,15 @@ namespace ElmahCore
 
         public override string Log(Error error)
         {
+            var newId = Guid.NewGuid();
+
+            Log(newId, error);
+
+            return newId.ToString();
+        }
+
+        public override void Log(Guid id, Error error)
+        {
             if (error == null)
                 throw new ArgumentNullException(nameof(error));
 
@@ -91,8 +100,7 @@ namespace ElmahCore
 
             error = error.Clone();
             error.ApplicationName = ApplicationName;
-            var newId = Guid.NewGuid();
-            var entry = new ErrorLogEntry(this, newId.ToString(), error);
+            var entry = new ErrorLogEntry(this, id.ToString(), error);
 
             Lock.EnterWriteLock(); 
 
@@ -105,8 +113,6 @@ namespace ElmahCore
             {
                 Lock.ExitWriteLock();
             }
-            
-            return newId.ToString();
         }
 
         /// <summary>

--- a/ElmahCore/Logs$/XmlFileErrorLog.cs
+++ b/ElmahCore/Logs$/XmlFileErrorLog.cs
@@ -59,18 +59,25 @@ namespace ElmahCore
         
         public override string Log(Error error)
         {
+            var errorId = Guid.NewGuid();
+
+            Log(errorId, error);
+
+            return errorId.ToString();
+        }
+
+        public override void Log(Guid id, Error error)
+        {
             var logPath = LogPath;
             if (!Directory.Exists(logPath))
                 Directory.CreateDirectory(logPath);
 
-            var errorId = Guid.NewGuid().ToString();
-            
             var timeStamp = (error.Time > DateTime.MinValue ? error.Time : DateTime.Now);
             
             var fileName = string.Format(CultureInfo.InvariantCulture, 
                                   @"error-{0:yyyy-MM-ddHHmmssZ}-{1}.xml", 
                                   /* 0 */ timeStamp.ToUniversalTime(), 
-                                  /* 1 */ errorId);
+                                  /* 1 */ id);
 
             var path = Path.Combine(logPath, fileName);
 
@@ -78,7 +85,7 @@ namespace ElmahCore
             {
                 using var writer = new XmlTextWriter(path, Encoding.UTF8) {Formatting = Formatting.Indented};
                 writer.WriteStartElement("error");
-                writer.WriteAttributeString("errorId", errorId);
+                writer.WriteAttributeString("errorId", id.ToString());
                 ErrorXml.Encode(error, writer);
                 writer.WriteEndElement();
                 writer.Flush();
@@ -93,8 +100,6 @@ namespace ElmahCore
                 File.Delete(path);
                 throw;
             }
-
-            return errorId;
         }
 
         /// <summary>


### PR DESCRIPTION
This change allows explicitly specifying error IDs when logging errors, rather than relying on the logger to generate them.

The reason we would like to be able to do is slightly complicated. We have extended the way we use ELMAH a bit. We don't log straight to a database from our web apps. Instead, all our apps log to a message bus (RabbitMQ). We then have several consumers of those messages/errors. One of those consumers logs the mesages/errors to a database, like normal ELMAH. Another consumer logs the messages/errors to Slack (a messaging platform). We would now like to provide links from the errors in Slack to the errors in the ELMAH error viewer, as the errors in Slack are often truncated. To be able to provide those links, we need to know the error ID in Slack. Since ELMAH currently assigns those IDs at log time we have no way of knowing those IDs when we log to Slack. Hence, why we would like to be able to specify the IDs explicitly. It would allow us to create the error ID when we log to the message bus, stick the ID in the message and then have it available when we log to the database, as well as Slack. We could then easily construct a link from Slack to the ELMAH error viewer, using this ID.

I hope that all makes sense. Let me know if you have any questions, or would like me to make any changes. I made the changes so that the `ErrorLog` "interface" is backwards compatible. I.e. all existing apps will continue the way they work, at the moment.