### PR TITLE
Fix#101 - invalid characters in XML causes read errors

### DIFF
--- a/ElmahCore.Mvc/ElmahCore.Mvc.csproj
+++ b/ElmahCore.Mvc/ElmahCore.Mvc.csproj
@@ -28,6 +28,7 @@
     <None Remove="wwwroot\js\*.js" />
     <None Remove="wwwroot\img\*.svg" />
     <None Remove="wwwroot\css\*.css" />
+    <None Remove="wwwroot\fonts\*.*" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,6 +36,7 @@
     <EmbeddedResource Include="wwwroot\js\*.js" />
     <EmbeddedResource Include="wwwroot\img\*.svg" />
     <EmbeddedResource Include="wwwroot\css\*.css" />
+    <EmbeddedResource Include="wwwroot\fonts\*.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ElmahCore/ElmahCore.csproj
+++ b/ElmahCore/ElmahCore.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
-	  <Version>2.0.6</Version>
+	  <Version>2.0.7</Version>
 	  <PackageProjectUrl>https://github.com/ElmahCore/ElmahCore</PackageProjectUrl>
-	  <AssemblyVersion>2.0.6.0</AssemblyVersion>
-	  <FileVersion>2.0.6.0</FileVersion>
+	  <AssemblyVersion>2.0.7.0</AssemblyVersion>
+	  <FileVersion>2.0.7.0</FileVersion>
 	  <AssemblyName>ElmahCore</AssemblyName>
 	  <PackageId>ElmahCore.Common</PackageId>
 	  <Authors>ElmahCore</Authors>

--- a/ElmahCore/ErrorXml.cs
+++ b/ElmahCore/ErrorXml.cs
@@ -22,7 +22,7 @@ namespace ElmahCore
         public static Error DecodeString(string xml)
         {
             using (var sr = new StringReader(xml))
-            using (var reader = XmlReader.Create(sr))
+            using (var reader = XmlReader.Create(sr, new XmlReaderSettings() { CheckCharacters = false }))
             {
                 if (!reader.IsStartElement("error"))
                     throw new ApplicationException("The error XML is not in the expected format.");


### PR DESCRIPTION
Amended `ErrorXml.cs` to use the same settings as the serializer so characters are not checked for validity.

Fixes #101 