### PR TITLE
#108 Make page variable and increment after each page search

### DIFF
--- a/ElmahCore/Logs$/ErrorLog.cs
+++ b/ElmahCore/Logs$/ErrorLog.cs
@@ -205,7 +205,7 @@ namespace ElmahCore
 
         public async Task<int> GetNewErrorsAsync(string id, List<ErrorLogEntry> entries)
         {
-            const int page = 0;
+            var page = 0;
             int cnt, count;
             do
             {
@@ -217,6 +217,7 @@ namespace ElmahCore
                     if (el.Id == id) return count;
                     entries.Add(el);
                 }
+                page++;
             } while (cnt > 0);
 
             return count;


### PR DESCRIPTION
Closes #108 @ElmahCore 

To fix the issue, I transformed the constant _page_ to a variable and incremented it after the errors loop.

It should help fixing the call onto the same page.
