### PR TITLE
fix (ElmahExtensions): Fix ElmahExtensions RiseError methods.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: dotnet package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        options:
+          - framework: netstandard2.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: DotNetBuild
+        shell: pwsh
+        run: ./ci-build.ps1 "${{matrix.options.framework}}"
+      - name: Test
+        run: dotnet test --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ ElmahCore.MySql/bin/**/*
 ElmahCore.MySql/obj/**/*
 /.vs/ElmahCore
 /.vs
+*/bin/**
+/ElmahCore.DemoCore5/wwwroot/log/*
+**/bin/**
+**/obj/**

--- a/ElmahCore.DemoCore3/Controllers/HomeController.cs
+++ b/ElmahCore.DemoCore3/Controllers/HomeController.cs
@@ -17,7 +17,7 @@ namespace ElmahCore.DemoCore3.Controllers
 
         public IActionResult Index()
         {
-            ElmahExtensions.RiseError(new InvalidOperationException("This is the Test Exception from code."));
+            ElmahExtensions.RaiseError(new InvalidOperationException("This is the Test Exception from code."));
 
             _logger.LogTrace("Test");
             _logger.LogDebug("Test");
@@ -26,7 +26,7 @@ namespace ElmahCore.DemoCore3.Controllers
             _logger.LogWarning("Test");
             _logger.LogCritical(new InvalidOperationException("Test"), "Test");
 
-            ElmahExtensions.RiseError(new NullReferenceException());
+            ElmahExtensions.RaiseError(new NullReferenceException());
 
             if (DateTime.Now.Millisecond < 500)
             {

--- a/ElmahCore.DemoCore5/Controllers/HomeController.cs
+++ b/ElmahCore.DemoCore5/Controllers/HomeController.cs
@@ -29,7 +29,7 @@ namespace ElmahCore.DemoCore5.Controllers
             _logger.LogWarning("Test");
             _logger.LogCritical(new InvalidOperationException("Test"), "Test");
 
-            ElmahExtensions.RiseError(new Exception("test2"));
+            ElmahExtensions.RaiseError(new Exception("test2"));
 
             var r = 0;
             // ReSharper disable once UnusedVariable

--- a/ElmahCore.Mvc/ElmahExtensions.cs
+++ b/ElmahCore.Mvc/ElmahExtensions.cs
@@ -18,19 +18,37 @@ namespace ElmahCore
                 throw new MiddlewareNotInitializedException("Elmah Middleware Not initialized");
         }
 
+        [Obsolete("Prefer RaiseError")]
         public static Task RiseError(this HttpContext ctx, Exception ex, Func<HttpContext, Error, Task> onError)
+        {
+            return RaiseError(ctx, ex, onError);
+        }
+
+        public static Task RaiseError(this HttpContext ctx, Exception ex, Func<HttpContext, Error, Task> onError)
         {
             GuardForNullMiddleware();
             return LogMiddleware.LogException(ex, ctx, onError);
         }
 
+        [Obsolete("Prefer RaiseError")]
         public static Task RiseError(this HttpContext ctx, Exception ex)
+        {
+            return RaiseError(ctx, ex);
+        }
+
+        public static Task RaiseError(this HttpContext ctx, Exception ex)
         {
             GuardForNullMiddleware();
             return LogMiddleware.LogException(ex, ctx, (context, error) => Task.CompletedTask);
         }
 
+        [Obsolete("Prefer RaiseError")]
         public static void RiseError(Exception ex)
+        {
+            RaiseError(ex);
+        }
+
+        public static void RaiseError(Exception ex)
         {
             LogMiddleware?.LogException(ex, InternalHttpContext.Current ?? new DefaultHttpContext(),
                 (context, error) => Task.CompletedTask);

--- a/ElmahCore.Mvc/ElmahExtensions.cs
+++ b/ElmahCore.Mvc/ElmahExtensions.cs
@@ -2,8 +2,8 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ElmahCore.Mvc;
+using ElmahCore.Mvc.Exceptions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
 namespace ElmahCore
@@ -12,16 +12,22 @@ namespace ElmahCore
     {
         internal static ErrorLogMiddleware LogMiddleware;
 
-        public static void RiseError(this HttpContext ctx, Exception ex, Func<HttpContext, Error, Task> onError)
+        private static void GuardForNullMiddleware()
         {
-            var middleware = ctx.RequestServices.GetService<ErrorLogMiddleware>();
-            middleware?.LogException(ex, ctx, onError);
+            if (LogMiddleware == null)
+                throw new MiddlewareNotInitializedException("Elmah Middleware Not initialized");
         }
 
-        public static void RiseError(this HttpContext ctx, Exception ex)
+        public static Task RiseError(this HttpContext ctx, Exception ex, Func<HttpContext, Error, Task> onError)
         {
-            var middleware = ctx.RequestServices.GetService<ErrorLogMiddleware>();
-            middleware?.LogException(ex, ctx, (context, error) => Task.CompletedTask);
+            GuardForNullMiddleware();
+            return LogMiddleware.LogException(ex, ctx, onError);
+        }
+
+        public static Task RiseError(this HttpContext ctx, Exception ex)
+        {
+            GuardForNullMiddleware();
+            return LogMiddleware.LogException(ex, ctx, (context, error) => Task.CompletedTask);
         }
 
         public static void RiseError(Exception ex)

--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -12,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+[assembly: InternalsVisibleTo("ElmahCore.Mvc.Tests")]
 namespace ElmahCore.Mvc
 {
     internal sealed class ErrorLogMiddleware

--- a/ElmahCore.Mvc/Exceptions/MiddlewareNotInitialisedException.cs
+++ b/ElmahCore.Mvc/Exceptions/MiddlewareNotInitialisedException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ElmahCore.Mvc.Exceptions
+{
+    public class MiddlewareNotInitializedException : Exception
+    {
+        public MiddlewareNotInitializedException(string message) : base(message)
+        {
+        }
+
+        public MiddlewareNotInitializedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/ElmahCore.Mvc/Exceptions/MiddlewareNotInitializedException.cs
+++ b/ElmahCore.Mvc/Exceptions/MiddlewareNotInitializedException.cs
@@ -2,11 +2,19 @@
 
 namespace ElmahCore.Mvc.Exceptions
 {
+    /// <inheritdoc />
     public class MiddlewareNotInitializedException : Exception
     {
+        // ReSharper disable once UnusedMember.Global
+        public MiddlewareNotInitializedException()
+        {
+        }
+
         public MiddlewareNotInitializedException(string message) : base(message)
         {
         }
+
+        // ReSharper disable once UnusedMember.Global
 
         public MiddlewareNotInitializedException(string message, Exception innerException) : base(message, innerException)
         {

--- a/ElmahCore.sln
+++ b/ElmahCore.sln
@@ -24,6 +24,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElmahCore.MySql", "ElmahCor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElmahCore.DemoCore5", "ElmahCore.DemoCore5\ElmahCore.DemoCore5.csproj", "{289FB7BF-7E2C-406D-9B46-360B5B4B8AAF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{93D72C8F-498F-4E86-AB88-6D77394CE495}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElmahCore.Mvc.Tests", "Tests\ElmahCore.Mvc.Tests\ElmahCore.Mvc.Tests.csproj", "{B54072F0-F35A-424C-A153-286152BA9272}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,6 +62,10 @@ Global
 		{289FB7BF-7E2C-406D-9B46-360B5B4B8AAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{289FB7BF-7E2C-406D-9B46-360B5B4B8AAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{289FB7BF-7E2C-406D-9B46-360B5B4B8AAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B54072F0-F35A-424C-A153-286152BA9272}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B54072F0-F35A-424C-A153-286152BA9272}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B54072F0-F35A-424C-A153-286152BA9272}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B54072F0-F35A-424C-A153-286152BA9272}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,6 +73,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{A6EABDE3-E1CD-43B5-BB15-880210D8FC3F} = {8E26F641-674E-421C-B37C-AF2A690DA1CF}
 		{289FB7BF-7E2C-406D-9B46-360B5B4B8AAF} = {8E26F641-674E-421C-B37C-AF2A690DA1CF}
+		{B54072F0-F35A-424C-A153-286152BA9272} = {93D72C8F-498F-4E86-AB88-6D77394CE495}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FABFFBFF-15DA-48E3-856C-4A82E42A292B}

--- a/Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj
+++ b/Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ElmahCore.Mvc\ElmahCore.Mvc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/ElmahCore.Mvc.Tests/ElmahExtensionsTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ElmahExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using ElmahCore.Mvc.Exceptions;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -12,9 +13,8 @@ namespace ElmahCore.Mvc.Tests
         public void RiseErrorExceptionWhenMiddlewareNotInitialised()
         {
             var httpContext = new DefaultHttpContext();
-            Action act = () => ElmahExtensions.RiseError(httpContext, new Exception());
-            act.Should().Throw<MiddlewareNotInitializedException>();
+            Func<Task> act = async () => await ElmahExtensions.RiseError(httpContext, new Exception());
+            act.Should().ThrowAsync<MiddlewareNotInitializedException>();
         }
-
     }
 }

--- a/Tests/ElmahCore.Mvc.Tests/ElmahExtensionsTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ElmahExtensionsTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using ElmahCore.Mvc.Exceptions;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace ElmahCore.Mvc.Tests
+{
+    public class ElmahExtensionsTests
+    {
+        [Fact]
+        public void RiseErrorExceptionWhenMiddlewareNotInitialised()
+        {
+            var httpContext = new DefaultHttpContext();
+            Action act = () => ElmahExtensions.RiseError(httpContext, new Exception());
+            act.Should().Throw<MiddlewareNotInitializedException>();
+        }
+
+    }
+}

--- a/Tests/ElmahCore.Mvc.Tests/ElmahExtensionsTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ElmahExtensionsTests.cs
@@ -13,7 +13,7 @@ namespace ElmahCore.Mvc.Tests
         public void RiseErrorExceptionWhenMiddlewareNotInitialised()
         {
             var httpContext = new DefaultHttpContext();
-            Func<Task> act = async () => await ElmahExtensions.RiseError(httpContext, new Exception());
+            Func<Task> act = async () => await ElmahExtensions.RaiseError(httpContext, new Exception());
             act.Should().ThrowAsync<MiddlewareNotInitializedException>();
         }
     }

--- a/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace ElmahCore.Mvc.Tests
+{
+    public class ErrorLogMiddlewareTests
+    {
+        private readonly RequestDelegate _requestDelegate;
+        private readonly ErrorLog _errorLog;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IOptions<ElmahOptions> _options;
+
+        public ErrorLogMiddlewareTests()
+        {
+            _requestDelegate = httpContext => Task.CompletedTask;
+            _options = Substitute.For<IOptions<ElmahOptions>>();
+            _loggerFactory = Substitute.For<ILoggerFactory>();
+            _errorLog = new MemoryErrorLog();
+        }
+
+        [Fact]
+        public void WhenInitMiddlewareSetsStaticExtension()
+        {
+            var middleware = new ErrorLogMiddleware(_requestDelegate, _errorLog, _loggerFactory, _options);
+            ElmahExtensions.LogMiddleware.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void RiseErrorOkWhenMiddlewareInitialized()
+        {
+            var middleware = new ErrorLogMiddleware(_requestDelegate, _errorLog, _loggerFactory, _options);
+            var httpContext = new DefaultHttpContext();
+            Action act = () => ElmahExtensions.RiseError(httpContext, new Exception());
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
@@ -36,7 +36,7 @@ namespace ElmahCore.Mvc.Tests
         {
             var middleware = new ErrorLogMiddleware(_requestDelegate, _errorLog, _loggerFactory, _options);
             var httpContext = new DefaultHttpContext();
-            Func<Task> act = async () => await ElmahExtensions.RiseError(httpContext, new Exception());
+            Func<Task> act = async () => await ElmahExtensions.RaiseError(httpContext, new Exception());
             act.Should().NotThrowAsync();
         }
     }

--- a/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
@@ -36,8 +36,8 @@ namespace ElmahCore.Mvc.Tests
         {
             var middleware = new ErrorLogMiddleware(_requestDelegate, _errorLog, _loggerFactory, _options);
             var httpContext = new DefaultHttpContext();
-            Action act = () => ElmahExtensions.RiseError(httpContext, new Exception());
-            act.Should().NotThrow();
+            Func<Task> act = async () => await ElmahExtensions.RiseError(httpContext, new Exception());
+            act.Should().NotThrowAsync();
         }
     }
 }

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,0 +1,15 @@
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$targetFramework
+)
+
+dotnet clean -c Release
+
+$repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
+
+# Building for a specific framework.
+dotnet build .\ElmahCore -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build .\ElmahCore.Mvc -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build .\ElmahCore.MySql -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build .\ElmahCore.MsSql -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl
+dotnet build .\ElmahCore.Postgresql -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl


### PR DESCRIPTION
fix to allow the ElmahExtension RiseError extension methods to function by configuring them to use the static reference the middleware sets.

- Will throw Exception if methods are used without the Middleware.
- Added github actions to build/test app.

Resolves #103 and #113