### PR TITLE
feat (Build): Add SemVer versioning via MinVer

### DIFF
--- a/ElmahCore.MsSql/ElmahCore.Sql.csproj
+++ b/ElmahCore.MsSql/ElmahCore.Sql.csproj
@@ -23,8 +23,16 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+<PropertyGroup>
+  <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+</PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 

--- a/ElmahCore.Mvc/ElmahCore.Mvc.csproj
+++ b/ElmahCore.Mvc/ElmahCore.Mvc.csproj
@@ -23,6 +23,10 @@
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
+<PropertyGroup>
+  <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+</PropertyGroup>
+
   <ItemGroup>
     <None Remove="wwwroot\index.html" />
     <None Remove="wwwroot\js\*.js" />
@@ -44,6 +48,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.6.0" />

--- a/ElmahCore.MySql/ElmahCore.MySql.csproj
+++ b/ElmahCore.MySql/ElmahCore.MySql.csproj
@@ -18,7 +18,15 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+<PropertyGroup>
+  <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+</PropertyGroup>
+
   <ItemGroup>
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MySql.Data" Version="8.0.22" />
   </ItemGroup>
 

--- a/ElmahCore.Postgresql/ElmahCore.Postgresql.csproj
+++ b/ElmahCore.Postgresql/ElmahCore.Postgresql.csproj
@@ -22,8 +22,16 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+<PropertyGroup>
+  <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+</PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 

--- a/ElmahCore/ElmahCore.csproj
+++ b/ElmahCore/ElmahCore.csproj
@@ -25,6 +25,10 @@
     <UserSecretsId>c3a38668-74c2-494f-b54d-1a06c261f315</UserSecretsId>
   </PropertyGroup>
 
+<PropertyGroup>
+  <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+</PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Error2.cs" />
   </ItemGroup>
@@ -39,6 +43,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Use git branch tags to version app.  Follow semver as outlined in [MinVer](https://github.com/adamralph/minver) notes.
This repo already uses standard convention version tagging of releases, minimal if any change to release versioning! :-) 
- Changed default `alpha` tag to `preview`

Resolves #116 