### PR TITLE
[#45] Provide the ability to specify the name of the elmah error table and schema in sql server

### DIFF
--- a/ElmahCore/ElmahOptions.cs
+++ b/ElmahCore/ElmahOptions.cs
@@ -47,6 +47,18 @@ namespace ElmahCore
         public string ConnectionString { get; set; }
 
         /// <summary>
+        ///     Database table name. Used with SqlErrorLog
+        ///     Default value if not provided = "ELMAH_Error"
+        /// </summary>
+        public string SqlServerDatabaseTableName { get; set; }
+
+        /// <summary>
+        ///     Database schema name. Used with SqlErrorLog
+        ///     Default value if not provided = "dbo"
+        /// </summary>
+        public string SqlServerDatabaseSchemaName { get; set; }
+
+        /// <summary>
         ///     Permission Check callback
         /// </summary>
         public Func<HttpContext, bool> OnPermissionCheck { get; set; } = context => true;

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ services.AddElmah<XmlFileErrorLog>(options =>
 services.AddElmah<SqlErrorLog>(options =>
 {
     options.ConnectionString = "connection_string";
+    options.SqlServerDatabaseSchemaName = "Errors"; //Defaults to dbo if not set
+    options.SqlServerDatabaseTableName = "ElmahError"; //Defaults to ELMAH_Error if not set
 });
 ```
 ## Rise exception


### PR DESCRIPTION
It will default to the existing schema and table names of [dbo].[ELMAH_Error] if different table or schema names aren't provided in the configuration. This means that existing behaviour will be unchanged.