### PR TITLE
Adds overload to call RiseError with callback

### DIFF
--- a/ElmahCore.Mvc/ElmahExtensions.cs
+++ b/ElmahCore.Mvc/ElmahExtensions.cs
@@ -24,10 +24,14 @@ namespace ElmahCore
             middleware?.LogException(ex, ctx, (context, error) => Task.CompletedTask);
         }
 
+        public static void RiseError(Exception ex, Func<HttpContext, Error, Task> onError)
+        {
+            LogMiddleware?.LogException(ex, InternalHttpContext.Current ?? new DefaultHttpContext(), onError);
+        }
+
         public static void RiseError(Exception ex)
         {
-            LogMiddleware?.LogException(ex, InternalHttpContext.Current ?? new DefaultHttpContext(),
-                (context, error) => Task.CompletedTask);
+            RiseError(ex, (context, error) => Task.CompletedTask);
         }
 
         public static void LogParams(this object source,


### PR DESCRIPTION
Previous overloads only allowed onError callback when HttpContext available. 
This allows onError callback when capturing exceptions outside of a HttpContext (eg. Hangfire background job)