### PR TITLE
Added HttpContext Feature for Elmah data.

### DIFF
--- a/ElmahCore.Mvc/ElmahFeature.cs
+++ b/ElmahCore.Mvc/ElmahFeature.cs
@@ -1,0 +1,22 @@
+﻿namespace ElmahCore.Mvc
+{
+    public interface IElmahFeature
+    {
+        public string Id { get; }
+
+        public string Location { get; }
+    }
+
+    internal class ElmahFeature : IElmahFeature
+    {
+        public ElmahFeature(string id, string location)
+        {
+            Id = id;
+            Location = location;
+        }
+
+        public string Id { get; }
+
+        public string Location { get; }
+    }
+}

--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -176,11 +176,14 @@ namespace ElmahCore.Mvc
             catch (Exception exception)
             {
                 var id = await LogException(exception, context, _onError, body);
+                var location = $"{_elmahRoot}/detail/{id}";
+
+                context.Features.Set<IElmahFeature>(new ElmahFeature(id, location));
 
                 //To next middleware
                 if (!ShowDebugPage) throw;
                 //Show Debug page
-                context.Response.Redirect($"{_elmahRoot}/detail/{id}");
+                context.Response.Redirect(location);
             }
         }
 


### PR DESCRIPTION
This change will allow access to the Elmah error entry id and URL location further down the pipeline. 

For example when using [UseExceptionHandler](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?view=aspnetcore-6.0#exception-handler-page) we can access the id and location for use on a custom error page.
```c#
var app = builder.Build();

if (!app.Environment.IsDevelopment())
{
    app.UseExceptionHandler("/Error");
}
```

```c#
public class ErrorController : Controller
{
    [Route("Error")]
    public IActionResult ServerError()
    {
        var feature = HttpContext.Features.Get<IElmahFeature>();
        var content = new ErrorResult
        {
            Id = feature?.Id,
            Location = feature?.Location,
        };
        return Content(JsonConvert.SerializeObject(content), "application/json");
    }
}
```

Features: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/request-features?view=aspnetcore-6.0