### PR TITLE
enhance (SQLLogger):  Allow configuration to run CreateTable method or not.

### DIFF
--- a/ElmahCore.MsSql/ElmahCore.Sql.csproj
+++ b/ElmahCore.MsSql/ElmahCore.Sql.csproj
@@ -28,7 +28,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ElmahCore.MsSql/SqlErrorLog.cs
+++ b/ElmahCore.MsSql/SqlErrorLog.cs
@@ -172,7 +172,7 @@ namespace ElmahCore.Sql
         }
 
         /// <summary>
-        ///     Creates the necessary tables and sequences used by this implementation
+        ///  Creates the necessary tables and sequences used by this implementation
         /// </summary>
         private void CreateTableIfNotExists()
         {

--- a/ElmahCore.Postgresql/ElmahCore.Postgresql.csproj
+++ b/ElmahCore.Postgresql/ElmahCore.Postgresql.csproj
@@ -27,7 +27,7 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ElmahCore.Postgresql/PgsqlErrorLog.cs
+++ b/ElmahCore.Postgresql/PgsqlErrorLog.cs
@@ -18,7 +18,7 @@ namespace ElmahCore.Postgresql
         ///     Initializes a new instance of the <see cref="PgsqlErrorLog" /> class
         ///     using a dictionary of configured settings.
         /// </summary>
-        public PgsqlErrorLog(IOptions<ElmahOptions> option) : this(option.Value.ConnectionString)
+        public PgsqlErrorLog(IOptions<ElmahOptions> option) : this(option.Value.ConnectionString, option.Value.CreateTablesIfNotExist)
         {
         }
 
@@ -26,14 +26,15 @@ namespace ElmahCore.Postgresql
         ///     Initializes a new instance of the <see cref="PgsqlErrorLog" /> class
         ///     to use a specific connection string for connecting to the database.
         /// </summary>
-        public PgsqlErrorLog(string connectionString)
+        public PgsqlErrorLog(string connectionString, bool createTablesIfNotExist)
         {
             if (string.IsNullOrEmpty(connectionString))
                 throw new ArgumentNullException("connectionString");
 
             ConnectionString = connectionString;
 
-            CreateTableIfNotExists();
+            if (createTablesIfNotExist)
+                CreateTableIfNotExists();
         }
 
         /// <summary>

--- a/ElmahCore/ElmahCore.csproj
+++ b/ElmahCore/ElmahCore.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 

--- a/ElmahCore/ElmahOptions.cs
+++ b/ElmahCore/ElmahOptions.cs
@@ -58,6 +58,8 @@ namespace ElmahCore
         /// </summary>
         public string SqlServerDatabaseSchemaName { get; set; }
 
+        public bool CreateTablesIfNotExist { get; set; } = true;
+
         /// <summary>
         ///     Permission Check callback
         /// </summary>

--- a/ElmahCore/ElmahOptions.cs
+++ b/ElmahCore/ElmahOptions.cs
@@ -58,6 +58,10 @@ namespace ElmahCore
         /// </summary>
         public string SqlServerDatabaseSchemaName { get; set; }
 
+        /// <summary>
+        /// Indicate if the CreateTables check should be run when initializing the logger.
+        /// Defaults to true
+        /// </summary>
         public bool CreateTablesIfNotExist { get; set; } = true;
 
         /// <summary>

--- a/Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj
+++ b/Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj
@@ -7,12 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add config option `CreateTablesIfNotExist` , default to true to keep existing functionality, to allow the user to configure not to run the `CreateTable` method (i.e. app may not have permission to do so)  

* Side effects. This may now put the Logger in an invalid state (MSSQL Unavailable, no tables etc),  so guard the Logger by silently catching all errors, to avoid stack overflow from logging errors creating errors loop.

should Resolves #120 