### PR TITLE
Add Request.PathBase to Request.Path

### DIFF
--- a/ElmahCore.Mvc/ErrorWrapper.cs
+++ b/ElmahCore.Mvc/ErrorWrapper.cs
@@ -207,7 +207,7 @@ namespace ElmahCore.Mvc
         [XmlElement("Url")]
         public string Url
         {
-            get => _error.ServerVariables["Path"];
+            get => _error.ServerVariables["PathBase"] + _error.ServerVariables["Path"];
             // ReSharper disable once ValueParameterNotUsed
             set { }
         }

--- a/ElmahCore.Mvc/Handlers/ErrorDigestRssHandler.cs
+++ b/ElmahCore.Mvc/Handlers/ErrorDigestRssHandler.cs
@@ -30,7 +30,7 @@ namespace ElmahCore.Mvc.Handlers
 
             var title = $@"Daily digest of errors in {log.ApplicationName} on {Environment.MachineName}";
 
-            var link = $"{context.Request.Scheme}://{context.Request.Host}{elmahRoot}";
+            var link = $"{context.Request.Scheme}://{context.Request.PathBase.ToString().TrimEnd('/')}{elmahRoot}";
             var baseUrl = new Uri(link.TrimEnd('/') + "/");
 
             var items = GetItems(log, baseUrl, 30, 30).Take(30);

--- a/ElmahCore.Mvc/Handlers/ErrorResourceHandler.cs
+++ b/ElmahCore.Mvc/Handlers/ErrorResourceHandler.cs
@@ -26,7 +26,7 @@ namespace ElmahCore.Mvc.Handlers
                 using (var reader = new StreamReader(stream2 ?? throw new InvalidOperationException()))
                 {
                     var html = await reader.ReadToEndAsync();
-                    html = html.Replace("ELMAH_ROOT", context.Request.PathBase + elmahRoot);
+                    html = html.Replace("ELMAH_ROOT", elmahRoot);
                     context.Response.ContentType = "text/html";
                     await context.Response.WriteAsync(html);
                     return;

--- a/ElmahCore.Mvc/Handlers/ErrorRssHandler.cs
+++ b/ElmahCore.Mvc/Handlers/ErrorRssHandler.cs
@@ -26,7 +26,7 @@ namespace ElmahCore.Mvc.Handlers
             var title = $@"Error log of {log.ApplicationName} on {Environment.MachineName}";
 
 
-            var link = $"{context.Request.Scheme}://{context.Request.Host}{elmahRoot}";
+            var link = $"{context.Request.Scheme}://{context.Request.PathBase.ToString().TrimEnd('/')}{elmahRoot}";
             var baseUrl = new Uri(link.TrimEnd('/') + "/");
 
             var items =


### PR DESCRIPTION
Resolves issue #152 

`ErrorLogMiddleware.cs`
* _elmaRoot default changed to `"~/elmah"`
* Replace the start of `~/` with `context.Request.PathBase`
* Anyone who set `ElmahOptions.Path` will not see new behavior (unless they set it to `~/something`, which currently does not work)

`ErrorWrapper.cs`
`ErrorDigestRssHandler.cs`
`ErrorRssHandler.cs`
* Concatinate `context.Request.PathBase` and `context.Request.Path`
* This does not use `ElmahOptions.Path`, so there is no need to replace `~/`

 