### PR TITLE
fix (Parser): Issue with parsing stacktrace causing high cpu

### DIFF
--- a/ElmahCore.Mvc/Internal$/ErrorDetailHelper.cs
+++ b/ElmahCore.Mvc/Internal$/ErrorDetailHelper.cs
@@ -125,32 +125,31 @@ namespace ElmahCore.Mvc
                 },
                 (t, m) => new
                 {
-                    Type = new {t.Index, t.End, Html = "<span class='st-type'>" + t.Html + "</span>"},
-                    Method = new {m.Index, m.End, Html = "<span class='st-method'>" + m.Html + "</span>"}
+                    Type = new {t.Index, t.End, Html = $"<span class='st-type'>{t.Html}</span>"},
+                    Method = new {m.Index, m.End, Html = $"<span class='st-method'>{m.Html}</span>"}
                 },
                 (t, n) => new
                 {
-                    Type = new {t.Index, t.End, Html = "<span class='st-param-type'>" + t.Html + "</span>"},
-                    Name = new {n.Index, n.End, Html = "<span class='st-param-name'>" + n.Html + "</span>"}
+                    Type = new {t.Index, t.End, Html = $"<span class='st-param-type'>{t.Html}</span>"},
+                    Name = new {n.Index, n.End, Html = $"<span class='st-param-name'>{n.Html}</span>"}
                 },
                 (p, ps) => new {List = p, Parameters = ps.ToArray()},
-                (f, l, m, t) =>
+                (f,l) =>
+                
                 {
                     if (int.TryParse(l.Html, out var line))
                         list.Add(new SourceInfo
                         {
                             Source = f.Html,
                             Line = line,
-                            Method = m.Html,
-                            Type = t.Html
                         });
                     return new
                     {
                         File = f.Html.Length > 0
-                            ? new {f.Index, f.End, Html = "<span class='st-file'>" + f.Html + "</span>"}
+                            ? new {f.Index, f.End, Html = $"<span class='st-file'>{f.Html}</span>"}
                             : null,
                         Line = l.Html.Length > 0
-                            ? new {l.Index, l.End, Html = "<span class='st-line'>" + l.Html + "</span>"}
+                            ? new {l.Index, l.End, Html = $"<span class='st-line'>{l.Html}</span>"}
                             : null
                     };
                 },
@@ -194,7 +193,7 @@ namespace ElmahCore.Mvc
                 where m.Length > 0
                 select m;
 
-            return string.Join(String.Empty, markups);
+            return string.Join(string.Empty, markups);
         }
     }
 }

--- a/ElmahCore.Mvc/Internal$/StackTraceParser.cs
+++ b/ElmahCore.Mvc/Internal$/StackTraceParser.cs
@@ -1,3 +1,18 @@
+#region Copyright (c) 2011 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -5,39 +20,63 @@ using System.Text.RegularExpressions;
 
 namespace ElmahCore.Mvc
 {
-    internal static class StackTraceParser
+    static class StackTraceParser
     {
-        private static readonly Regex Regex = new Regex(@"
+        const string Space = @"[\x20\t]";
+        const string NotSpace = @"[^\x20\t]";
+
+        static readonly Regex Regex = new Regex(@"
             ^
-            \s*
-            \w+ \s+ 
+            " + Space + @"*
+            \w+ " + Space + @"+
             (?<frame>
-                (?<type> .+ ) \.
-                (?<method> .+? ) \s*
-                (?<params>  \( ( \s* \)
-                               |        (?<pt> .+?) \s+ (?<pn> .+?) 
-                                 (, \s* (?<pt> .+?) \s+ (?<pn> .+?) )* \) ) )
-                ( \s+
+                (?<type> " + NotSpace + @"+ ) \.
+                (?<method> " + NotSpace + @"+? ) " + Space + @"*
+                (?<params>  \( ( " + Space + @"* \)
+                               |                    (?<pt> .+?) " + Space + @"+ (?<pn> .+?)
+                                 (, " + Space + @"* (?<pt> .+?) " + Space + @"+ (?<pn> .+?) )* \) ) )
+                ( " + Space + @"+
                     ( # Microsoft .NET stack traces
-                    \w+ \s+ 
-                    (?<file> [a-z] \: .+? ) 
-                    \: \w+ \s+ 
-                    (?<line> [0-9]+ ) \p{P}?  
+                    \w+ " + Space + @"+
+                    (?<file> ( [a-z] \: # Windows rooted path starting with a drive letter
+                             | / )      # *nix rooted path starting with a forward-slash
+                             .+? )
+                    \: \w+ " + Space + @"+
+                    (?<line> [0-9]+ ) \p{P}?
                     | # Mono stack traces
-                    \[0x[0-9a-f]+\] \s+ \w+ \s+ 
+                    \[0x[0-9a-f]+\] " + Space + @"+ \w+ " + Space + @"+
                     <(?<file> [^>]+ )>
                     :(?<line> [0-9]+ )
                     )
                 )?
             )
-            \s* 
+            \s*
             $",
             RegexOptions.IgnoreCase
             | RegexOptions.Multiline
             | RegexOptions.ExplicitCapture
             | RegexOptions.CultureInvariant
             | RegexOptions.IgnorePatternWhitespace
-            | RegexOptions.Compiled);
+            | RegexOptions.Compiled,
+            // Cap the evaluation time to make it obvious should the expression
+            // fall into the "catastrophic backtracking" trap due to over generalization.
+            // https://github.com/atifaziz/StackTraceParser/issues/4
+            TimeSpan.FromSeconds(5));
+
+        public static IEnumerable<T> Parse<T>(
+            string text,
+            Func<string, string, string, string, IEnumerable<KeyValuePair<string, string>>, string, string, T> selector)
+        {
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+
+            return Parse(text, (idx, len, txt) => txt,
+                               (t, m) => new { Type = t, Method = m },
+                               (pt, pn) => new KeyValuePair<string, string>(pt, pn),
+                               // ReSharper disable once PossibleMultipleEnumeration
+                               (pl, ps) => new { List = pl, Items = ps },
+                               (fn, ln) => new { File = fn, Line = ln },
+                               (f, tm, p, fl) => selector(f, tm.Type, tm.Method, p.List, p.Items, fl.File, fl.Line));
+        }
 
         public static IEnumerable<TFrame> Parse<TToken, TMethod, TParameters, TParameter, TSourceLocation, TFrame>(
             string text,
@@ -45,30 +84,34 @@ namespace ElmahCore.Mvc
             Func<TToken, TToken, TMethod> methodSelector,
             Func<TToken, TToken, TParameter> parameterSelector,
             Func<TToken, IEnumerable<TParameter>, TParameters> parametersSelector,
-            Func<TToken, TToken, TToken, TToken, TSourceLocation> sourceLocationSelector,
+            Func<TToken, TToken, TSourceLocation> sourceLocationSelector,
             Func<TToken, TMethod, TParameters, TSourceLocation, TFrame> selector)
         {
+            if (tokenSelector == null) throw new ArgumentNullException(nameof(tokenSelector));
+            if (methodSelector == null) throw new ArgumentNullException(nameof(methodSelector));
+            if (parameterSelector == null) throw new ArgumentNullException(nameof(parameterSelector));
+            if (parametersSelector == null) throw new ArgumentNullException(nameof(parametersSelector));
+            if (sourceLocationSelector == null) throw new ArgumentNullException(nameof(sourceLocationSelector));
+            if (selector == null) throw new ArgumentNullException(nameof(selector));
+
             return from Match m in Regex.Matches(text)
-                select m.Groups
-                into groups
-                let pt = groups["pt"].Captures
-                let pn = groups["pn"].Captures
-                select selector(Token(groups["frame"], tokenSelector),
-                    methodSelector(
-                        Token(groups["type"], tokenSelector),
-                        Token(groups["method"], tokenSelector)),
-                    parametersSelector(
-                        Token(groups["params"], tokenSelector),
-                        from i in Enumerable.Range(0, pt.Count)
-                        select parameterSelector(Token(pt[i], tokenSelector),
-                            Token(pn[i], tokenSelector))),
-                    sourceLocationSelector(Token(groups["file"], tokenSelector),
-                        Token(groups["line"], tokenSelector),
-                        Token(groups["method"], tokenSelector),
-                        Token(groups["type"], tokenSelector)));
+                   select m.Groups into groups
+                   let pt = groups["pt"].Captures
+                   let pn = groups["pn"].Captures
+                   select selector(Token(groups["frame"], tokenSelector),
+                                   methodSelector(
+                                       Token(groups["type"], tokenSelector),
+                                       Token(groups["method"], tokenSelector)),
+                                   parametersSelector(
+                                       Token(groups["params"], tokenSelector),
+                                       from i in Enumerable.Range(0, pt.Count)
+                                       select parameterSelector(Token(pt[i], tokenSelector),
+                                                                Token(pn[i], tokenSelector))),
+                                   sourceLocationSelector(Token(groups["file"], tokenSelector),
+                                                          Token(groups["line"], tokenSelector)));
         }
 
-        private static T Token<T>(Capture capture, Func<int, int, string, T> tokenSelector)
+        static T Token<T>(Capture capture, Func<int, int, string, T> tokenSelector)
         {
             return tokenSelector(capture.Index, capture.Length, capture.Value);
         }

--- a/Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj
+++ b/Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/ElmahCore.Mvc.Tests/StacktraceParser/ParseStackTrace.cs
+++ b/Tests/ElmahCore.Mvc.Tests/StacktraceParser/ParseStackTrace.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace ElmahCore.Mvc.Tests.StacktraceParser
+{
+    public class ParseStackTrace
+    {
+        private List<SourceInfo> list = new List<SourceInfo>();
+
+        [Fact]
+        public void CanParseStackTraceString()
+        {
+            var frames = StackTraceParser.Parse
+            (
+                GetTestStackStringIssue158_HighCPULoop(),
+                (idx, len, txt) => new
+                {
+                    Index = idx,
+                    End = idx + len,
+                    Html = txt.Length > 0
+                        ? WebUtility.HtmlEncode(txt)
+                        : string.Empty
+                },
+                (t, m) => new
+                {
+                    Type = new { t.Index, t.End, Html = $"<span class='st-type'>{t.Html}</span>" },
+                    Method = new { m.Index, m.End, Html = $"<span class='st-method'>{m.Html}</span>" }
+                },
+                (t, n) => new
+                {
+                    Type = new { t.Index, t.End, Html = $"<span class='st-param-type'>{t.Html}</span>" },
+                    Name = new { n.Index, n.End, Html = $"<span class='st-param-name'>{n.Html}</span>" }
+                },
+                (p, ps) => new { List = p, Parameters = ps.ToArray() },
+                (f, l) =>
+
+                {
+                    if (int.TryParse(l.Html, out var line))
+                        list.Add(new SourceInfo
+                        {
+                            Source = f.Html,
+                            Line = line,
+                        });
+                    return new
+                    {
+                        File = f.Html.Length > 0
+                            ? new { f.Index, f.End, Html = $"<span class='st-file'>{f.Html}</span>" }
+                            : null,
+                        Line = l.Html.Length > 0
+                            ? new { l.Index, l.End, Html = $"<span class='st-line'>{l.Html}</span>" }
+                            : null
+                    };
+                },
+                (f, tm, p, fl) =>
+                    from tokens in new[]
+                    {
+                        new[]
+                        {
+                            new { f.Index, End = f.Index, Html = "<span class='st-frame'>" },
+                            tm.Type,
+                            tm.Method,
+                            new { p.List.Index, End = p.List.Index, Html = "<span class='params'>" }
+                        },
+                        from pe in p.Parameters
+                        from e in new[] { pe.Type, pe.Name }
+                        select e,
+                        new[]
+                        {
+                            new { Index = p.List.End, p.List.End, Html = "</span>" },
+                            fl.File,
+                            fl.Line,
+                            new { Index = f.End, f.End, Html = "</span>" }
+                        }
+                    }
+                    from token in tokens
+                    where token != null
+                    select token
+            );
+
+            frames.Should().NotBeNull();
+        }
+
+        public string GetTestStackStringIssue158_HighCPULoop()
+        {
+            return @"
+# caller: @C:\Sources\ElmahCore\ElmahCore\ElmahCore\Internal$\CallerInfo.cs:9
+MySqlConnector.MySqlException (0x80004005): Column 'OrganizationNodeName' cannot be null
+   at MySqlConnector.Core.ResultSet.ReadResultSetHeaderAsync(IOBehavior ioBehavior) in /_/src/MySqlConnector/Core/ResultSet.cs:line 43
+   at MySqlConnector.MySqlDataReader.ActivateResultSet(CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 132
+   at MySqlConnector.MySqlDataReader.CreateAsync(CommandListPosition commandListPosition, ICommandPayloadCreator payloadCreator, IDictionary`2 cachedProcedures, IMySqlCommand command, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlDataReader.cs:line 466
+   at MySqlConnector.Core.CommandExecutor.ExecuteReaderAsync(IReadOnlyList`1 commands, ICommandPayloadCreator payloadCreator, CommandBehavior behavior, Activity activity, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/Core/CommandExecutor.cs:line 56
+   at MySqlConnector.MySqlCommand.ExecuteNonQueryAsync(IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 296
+   at MySqlConnector.MySqlCommand.ExecuteNonQuery() in /_/src/MySqlConnector/MySqlCommand.cs:line 107
+   at PMIS.DAL.MySQL.OrganizationNodeDAL.UpdateName(String organizationId, String nodeId, String name) in C:\git2017\PMIS.DAL\MySQL\OrganizationNodeDal.cs:line 135
+   at PMIS.Service.OrganizationNodeService.UpdateName(Account user, String nodeId, String newName) in C:\git2017\PMIS.Service\OrganizationNodeService.cs:line 258
+   at PMIS.Controllers.OrganizationNodeController.UpdateName(String nodeId, String name, String bindProjectId) in C:\git2017\PMISCore\Controllers\OrganizationNodeController.cs:line 110
+   at lambda_method(Closure , Object )
+   at Microsoft.Extensions.Internal.ObjectMethodExecutorAwaitable.Awaiter.GetResult()
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.TaskOfActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+--- End of stack trace from previous location where exception was thrown ---
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+--- End of stack trace from previous location where exception was thrown ---
+   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
+   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+   at ElmahCore.Mvc.ErrorLogMiddleware.InvokeAsync(HttpContext context)";
+        }
+    }
+}


### PR DESCRIPTION
fix (Parser): Issue with parsing stacktrace causing high cpu,   resolves #158


- appears to be the issue fixed in `StackTraceParser regex due to "catastrophic backtracking"`
- REF: See https://github.com/atifaziz/StackTraceParser/issues/4 for details
- Parser updated to current code in [StackTraceParser](https://github.com/atifaziz/StackTraceParser)