### PR TITLE
Add default async implementations of ErrorLog sub-classes

### DIFF
--- a/ElmahCore.MySql/MySqlErrorLog.cs
+++ b/ElmahCore.MySql/MySqlErrorLog.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using MySql.Data.MySqlClient;
 
@@ -68,6 +70,27 @@ namespace ElmahCore.MySql
             }
         }
 
+        public override async Task<string> LogAsync(Error error, CancellationToken cancellationToken)
+        {
+            if (error == null)
+                throw new ArgumentNullException("error");
+
+            var id = Guid.NewGuid();
+
+            var errorXml = ErrorXml.EncodeString(error);
+
+            using (var connection = new MySqlConnection(ConnectionString))
+            using (var command = CommandExtension.LogError(id, ApplicationName, error.HostName, error.Type,
+                error.Source, error.Message, error.User, error.StatusCode, error.Time, errorXml))
+            {
+                command.Connection = connection;
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return id.ToString();
+        }
+
         public override ErrorLogEntry GetError(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
@@ -101,6 +124,39 @@ namespace ElmahCore.MySql
             return new ErrorLogEntry(this, id, error);
         }
 
+        public override async Task<ErrorLogEntry> GetErrorAsync(string id, CancellationToken cancellationToken)
+        {
+            if (id == null) throw new ArgumentNullException("id");
+            if (id.Length == 0) throw new ArgumentException(null, "id");
+
+            Guid errorGuid;
+
+            try
+            {
+                errorGuid = new Guid(id);
+            }
+            catch (FormatException e)
+            {
+                throw new ArgumentException(e.Message, "id", e);
+            }
+
+            string errorXml;
+
+            using (var connection = new MySqlConnection(ConnectionString))
+            using (var command = CommandExtension.GetErrorXml(ApplicationName, errorGuid))
+            {
+                command.Connection = connection;
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                errorXml = (string)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            if (errorXml == null)
+                return null;
+
+            var error = ErrorXml.DecodeString(errorXml);
+            return new ErrorLogEntry(this, id, error);
+        }
+
         public override int GetErrors(string searchText, List<ErrorLogFilter> filters, int errorIndex, int pageSize,
             ICollection<ErrorLogEntry> errorEntryList)
         {
@@ -118,6 +174,36 @@ namespace ElmahCore.MySql
                     using (var reader = command.ExecuteReader())
                     {
                         while (reader.Read())
+                        {
+                            var id = reader.GetGuid(0);
+                            var xml = reader.GetString(1);
+                            var error = ErrorXml.DecodeString(xml);
+                            errorEntryList.Add(new ErrorLogEntry(this, id.ToString(), error));
+                        }
+                    }
+                }
+
+                return GetTotalErrorsXml(connection);
+            }
+        }
+
+        public override async Task<int> GetErrorsAsync(string searchText, List<ErrorLogFilter> errorLogFilters, int errorIndex, int pageSize, 
+            ICollection<ErrorLogEntry> errorEntryList, CancellationToken cancellationToken)
+        {
+            if (errorIndex < 0) throw new ArgumentOutOfRangeException("errorIndex", errorIndex, null);
+            if (pageSize < 0) throw new ArgumentOutOfRangeException("pageSize", pageSize, null);
+
+            using (var connection = new MySqlConnection(ConnectionString))
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                using (var command = CommandExtension.GetErrorsXml(ApplicationName, errorIndex, pageSize))
+                {
+                    command.Connection = connection;
+
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
                         {
                             var id = reader.GetGuid(0);
                             var xml = reader.GetString(1);

--- a/ElmahCore.Postgresql/PgsqlErrorLog.cs
+++ b/ElmahCore.Postgresql/PgsqlErrorLog.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using Npgsql;
 using NpgsqlTypes;
@@ -73,6 +75,27 @@ namespace ElmahCore.Postgresql
             }
         }
 
+        public override async Task<string> LogAsync(Error error, CancellationToken cancellationToken)
+        {
+            if (error == null)
+                throw new ArgumentNullException("error");
+
+            var id = Guid.NewGuid();
+
+            var errorXml = ErrorXml.EncodeString(error);
+
+            using (var connection = new NpgsqlConnection(ConnectionString))
+            using (var command = Commands.LogError(id, ApplicationName, error.HostName, error.Type, error.Source,
+                error.Message, error.User, error.StatusCode, error.Time, errorXml))
+            {
+                command.Connection = connection;
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return id.ToString();
+        }
+
         public override ErrorLogEntry GetError(string id)
         {
             if (id == null) throw new ArgumentNullException("id");
@@ -97,6 +120,39 @@ namespace ElmahCore.Postgresql
                 command.Connection = connection;
                 connection.Open();
                 errorXml = (string) command.ExecuteScalar();
+            }
+
+            if (errorXml == null)
+                return null;
+
+            var error = ErrorXml.DecodeString(errorXml);
+            return new ErrorLogEntry(this, id, error);
+        }
+
+        public override async Task<ErrorLogEntry> GetErrorAsync(string id, CancellationToken cancellationToken)
+        {
+            if (id == null) throw new ArgumentNullException("id");
+            if (id.Length == 0) throw new ArgumentException(null, "id");
+
+            Guid errorGuid;
+
+            try
+            {
+                errorGuid = new Guid(id);
+            }
+            catch (FormatException e)
+            {
+                throw new ArgumentException(e.Message, "id", e);
+            }
+
+            string errorXml;
+
+            using (var connection = new NpgsqlConnection(ConnectionString))
+            using (var command = Commands.GetErrorXml(ApplicationName, errorGuid))
+            {
+                command.Connection = connection;
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                errorXml = (string)await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
             }
 
             if (errorXml == null)
@@ -136,6 +192,39 @@ namespace ElmahCore.Postgresql
                 {
                     command.Connection = connection;
                     return Convert.ToInt32(command.ExecuteScalar());
+                }
+            }
+        }
+
+        public override async Task<int> GetErrorsAsync(string searchText, List<ErrorLogFilter> errorLogFilters, int errorIndex, int pageSize, ICollection<ErrorLogEntry> errorEntryList, CancellationToken cancellationToken)
+        {
+            if (errorIndex < 0) throw new ArgumentOutOfRangeException("errorIndex", errorIndex, null);
+            if (pageSize < 0) throw new ArgumentOutOfRangeException("pageSize", pageSize, null);
+
+            using (var connection = new NpgsqlConnection(ConnectionString))
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                using (var command = Commands.GetErrorsXml(ApplicationName, errorIndex, pageSize))
+                {
+                    command.Connection = connection;
+
+                    using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                        {
+                            var id = reader.GetGuid(0);
+                            var xml = reader.GetString(1);
+                            var error = ErrorXml.DecodeString(xml);
+                            errorEntryList.Add(new ErrorLogEntry(this, id.ToString(), error));
+                        }
+                    }
+                }
+
+                using (var command = Commands.GetErrorsXmlTotal(ApplicationName))
+                {
+                    command.Connection = connection;
+                    return Convert.ToInt32(await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
                 }
             }
         }


### PR DESCRIPTION
Add implementations of LogAsync, GetErrorAsync, GetErrorsAsync for ErrorLog sub-classes.

This will improve throughput when doing a lot of I/O and solve an issue we have had when a lot of errors were logged in quick succession. 